### PR TITLE
Show project To-Dos immediately

### DIFF
--- a/src/classes/Project.ts
+++ b/src/classes/Project.ts
@@ -71,8 +71,11 @@ export class Project implements IProject {
         <p style="color: #969696;">Estimated Progress</p>
         <p>${this.progress * 100}%</p>
       </div>
-    </div>`
+    </div>
+    <div class="todos-container"></div>`
+    
     this.ui.querySelector('.project-icon')?.addEventListener('click', () => this.showEditForm())
+    this.updateTodosUI()
   }
 
   addTodo(text: string, status: TodoStatus = "pending"): ITodo {


### PR DESCRIPTION
## Summary
- Add initial todos container to project card markup.
- Populate project cards with existing To-Dos when created.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx --yes ts-node --compiler-options '{"module":"CommonJS"}' test-todos.ts`

------
https://chatgpt.com/codex/tasks/task_e_6893c37cd1d0832e903982b13821d71a