### PR TITLE
Reattach project edit handler after UI updates

### DIFF
--- a/src/classes/Project.ts
+++ b/src/classes/Project.ts
@@ -73,9 +73,12 @@ export class Project implements IProject {
       </div>
     </div>
     <div class="todos-container"></div>`
-    
-    this.ui.querySelector('.project-icon')?.addEventListener('click', () => this.showEditForm())
+    this.attachEditHandler()
     this.updateTodosUI()
+  }
+
+  attachEditHandler() {
+    this.ui.querySelector('.project-icon')?.addEventListener('click', () => this.showEditForm())
   }
 
   addTodo(text: string, status: TodoStatus = "pending"): ITodo {
@@ -199,6 +202,7 @@ export class Project implements IProject {
         </div>
         <div class="todos-container"></div>
       `
+      this.attachEditHandler()
       this.updateTodosUI()
     }
   }


### PR DESCRIPTION
## Summary
- ensure project edit dialog click handler is restored after calling `updateUI`
- extract common logic to `attachEditHandler`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893c618d308832e945c100dc3ae5299