### PR TITLE
Add build script and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# That Open Master
+
+This project uses [Vite](https://vitejs.dev/) for development and building.
+
+## Development
+
+Run a local dev server:
+
+```sh
+npm run dev
+```
+
+## Deployment
+
+Build the project for production to generate the `dist` directory:
+
+```sh
+npm run build
+```
+
+Use the files from `dist` for deployment.
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "vite build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `vite build` script for production builds
- document build process and deployment instructions in new README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c7c2b7f8832eac4d98d5d82c8a2c